### PR TITLE
Ensure 0 cost calls still logs as ResultState.Success

### DIFF
--- a/src/Domain.RateLimiting.Core/RateLimiter.cs
+++ b/src/Domain.RateLimiting.Core/RateLimiter.cs
@@ -26,12 +26,12 @@ namespace Domain.RateLimiting.Core
         {
             if (_policyProvider == null && getPolicyFuncAsync == null)
                 throw new ArgumentNullException("There are no valid policy providers");
-
+            
             var getPolicyAsync = getPolicyFuncAsync ??  _policyProvider.GetPolicyAsync;
 
             var rateLimitingPolicy = await getPolicyAsync(rateLimitingRequest).ConfigureAwait(false);
 
-            if (rateLimitingPolicy == null || rateLimitingPolicy.CostPerCall == 0)
+            if (rateLimitingPolicy == null)
             {
                 if(onPostLimitFuncAsync != null)
                     await onPostLimitFuncAsync.Invoke(rateLimitingRequest, rateLimitingPolicy, new RateLimitingResult(ResultState.NotApplicable)).ConfigureAwait(false);


### PR DESCRIPTION
Reason: We need the zero cost calls to still call the PostOperationDecisionFuncAsync

This PR may not be complete, as I only wanted to demonstrate one way of doing what we need to do. This may not be what you want the rate limiter to actually do though.